### PR TITLE
DRAFT - make tag buttons tri-state (frontend only)

### DIFF
--- a/src/components/button/Button.svelte
+++ b/src/components/button/Button.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   export let disabled = false;
   export let click = () => {};
-  export let toggle = false;
+  export let active = false;
+  export let exclude = false;
 </script>
 
 
 <button
-  class={`${toggle ? 'active': ''} ${disabled ? 'disabled': ''}`}
+  class:active
+  class:exclude
+  class:disabled
   on:click={() => click()}
   disabled={disabled}
 >
@@ -38,6 +41,11 @@
   .active {
     color: #F9F5EB;
     background-color: #4E7539;
+  }
+
+  .exclude {
+    color: #F9F5EB;
+    background-color: #7C1010;
   }
 
   .disabled {

--- a/src/components/button/Switch.svelte
+++ b/src/components/button/Switch.svelte
@@ -7,7 +7,7 @@
 </script>
 
 
-<Button click={click} toggle={toggle} disabled={disabled}>
+<Button click={click} active={toggle} disabled={disabled}>
   <slot></slot>
 
   {#if toggle}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,7 +47,7 @@
   }
 
   /* Changing url */
-  $:tagsParam = ($page.url.searchParams.get('tags'))?.split(',')
+  $:tagsParam = ($page.url.searchParams.get('tags'))?.split(',') || []
   $:qParam = $page.url.searchParams.get('q')
   $:remoteParam = $page.url.searchParams.get('remote')
   $:savedParam = $page.url.searchParams.get('savedJobs')
@@ -100,12 +100,14 @@
   });
 
   /* Tags */
-  let tagsToFilter: string[] = [];
   function handleTags(tag: string) {
-    if (tagsToFilter.includes(tag)) {
-      tagsToFilter = tagsToFilter.filter((t) => t !== tag);
+    let negated = '-' + tag;
+    if (tagsParam.includes(tag)) {
+      tagsParam = [...tagsParam.filter((t) => t !== tag), negated];
+    } else if (tagsParam.includes(negated)) {
+      tagsParam = tagsParam.filter((t) => t !== negated);
     } else {
-      tagsToFilter = [...tagsToFilter, tag];
+      tagsParam = [...tagsParam, tag];
     }
   }
 
@@ -155,8 +157,8 @@
     <div class="pv-1">
       <div class="flex-and-row-wrap gap-half v-center min-h-4">
         <span class="heading wavy">Popular Filters</span>
-        {#if tagsToFilter.length > 0 || tagsParam != null}
-          <Reset click={() => tagsToFilter = []}>reset</Reset>
+        {#if tagsParam.length > 0}
+          <Reset click={() => tagsParam = []}>reset</Reset>
         {/if}
       </div>
       <div class="tags-container flex-and-row-wrap gap-half">
@@ -165,7 +167,8 @@
           {#each tags as tag}
             <div>
               <Button
-                toggle={tagsToFilter.includes(tag) || tagsParam?.includes(tag)}
+                active={tagsParam.includes(tag)}
+                exclude={tagsParam.includes('-' + tag)}
                 click={() => handleTags(tag)}>
                   {tag}
               </Button>
@@ -216,11 +219,11 @@
     {/if}
 
     <!-- Use hidden input to send tags info in URL -->
-    {#if tagsToFilter.length > 0}
+    {#if tagsParam.length > 0}
       <input
         type="hidden"
         name="tags"
-        value={tagsToFilter}
+        value={tagsParam}
       />
     {/if}
 


### PR DESCRIPTION
Idea for enabling negated tags on the frontend: buttons are now tri-state so toggle between include, exclude, and back to default.

The exclusion is done by prepending the tag with `-`.

The backend doesn't do anything with this yet as I'm not familiar with the postgres/ORM syntax used in fetch.ts. (It seems to treat the `-` prefixed tags the same as unprefixed.)